### PR TITLE
fixed issue with deadman switch sending notices at wrong time

### DIFF
--- a/app/controllers/dead_man_switch_controller.rb
+++ b/app/controllers/dead_man_switch_controller.rb
@@ -6,7 +6,7 @@ class DeadManSwitchController < ApplicationController
     @dead_man_switch = DeadManSwitch.find_or_create_by(user_id: @user.id)
     @dead_man_switch.update(interval_in_seconds: @length_of_time_for_switch)
     data = {
-      "updated_at": "#{@updated_at}",
+      "updated_at": "#{@dead_man_switch.updated_at.to_i}",
       "interval": "#{@user.dead_man_switch.interval_in_seconds}",
       "user_id": "#{@user.id}"
     }
@@ -14,7 +14,6 @@ class DeadManSwitchController < ApplicationController
     service_results(data)
     session[:time_difference] = service_results(data)[:time_difference]
     session[:formatted_date] = expiration_date
-    # flash[:message] = "Your Dead Man Switch has been created and will expire on #{expiration_date}."
     redirect_to notification_path
   end
 
@@ -23,16 +22,14 @@ class DeadManSwitchController < ApplicationController
     @user.dead_man_switch.touch
     @user.dead_man_switch.update(one_day_message_sent:  false)
     @user.dead_man_switch.update(one_hour_message_sent: false)
-    @updated_at = @user.dead_man_switch.updated_at.to_i
     data = {
-      "updated_at": "#{@updated_at}",
+      "updated_at": "#{@user.dead_man_switch.updated_at.to_i}",
       "interval": "#{@user.dead_man_switch.interval_in_seconds}",
       "user_id": "#{@user.id}"
     }
     data = data.to_json
     session[:time_difference] = service_results(data)[:time_difference]
     session[:formatted_date] = expiration_date
-    # flash[:message] = "Your Dead Man Switch has been reset and will expire on #{expiration_date}."
     redirect_to notification_path
   end
 
@@ -41,11 +38,8 @@ class DeadManSwitchController < ApplicationController
     @switch = DeadManSwitch.find(@user.dead_man_switch.id)
     @switch.destroy
     flash[:message] = "Your switch has been cancelled."
-
     redirect_to profile_path(@user)
   end
-
-
 
   private
 

--- a/app/controllers/notification_controller.rb
+++ b/app/controllers/notification_controller.rb
@@ -1,12 +1,4 @@
 class NotificationController < ApplicationController
-  # This controller queries the endpoint from the dead_man_switch miniservice
-  # and receive a time difference (as an integer) and a user id (as an integer).
-  # If the time difference is positive, then the switch has expired.
-  # If the time difference negative, then the switch has not expired
-  # 1 day = 24 hours = 1440 minutes = 86400 seconds
-  # one_day_plus_one_min = -86460 # i.e. this dms will expire in 1 day and 1 minutes
-  # one_day = -86400
-  # one_day_minues_one_min = -86340
 
   def message_sender
     @user = current_user
@@ -16,11 +8,6 @@ class NotificationController < ApplicationController
     @timer_one_day_message = "Coffin timer will expire in less than 24 hours."
     @timer_one_hour_message = "Coffin timer will expire in less than 1 hour."
     @timer_expired_message = "Coffin timer expired. Your info has been released."
-    # respond_to do |format|
-      # if @time_difference > 86400
-      #   @user.dead_man_switch.update(one_day_message_sent: false)
-      #   @user.dead_man_switch.update(one_hour_message_sent: false)
-      #   @user.dead_man_switch.update(expired_message_sent: false)
       if @time_difference <= 86415 && @user.dead_man_switch.one_day_message_sent == false
         message = @timer_one_day_message
         # TwilioTextMessenger.new(message).call # this is the syntax from Twilio to 'call' the message method
@@ -39,6 +26,5 @@ class NotificationController < ApplicationController
         @user.update(deceased: true)
       end
       redirect_to dashboard_path
-    # end
   end
 end


### PR DESCRIPTION
- [] Wrote Tests
- [x] Implemented
- [] Reviewed

# Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

## Type of change
- [] New feature
- [x] Bug Fix

# Implements/Fixes: messages sent at wrong time
## Description of Changes:  When the deadman switch was pressed, the app functioned normally.  When the interval timer for the switch was changed to a different time, the app would send out the 24 hour notice message, even if the time was well outside 24hrs.  Problem was located to the deadman switch controller create action, where the deadman switch updated_at time was not being passed in correctly.  Changed the code to properly pass in this attribute, and now the app functions as it should.

closes #

# Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

# Testing Changes
- [x] No Tests have been changed
- [] Some Tests have been changed
- [] All of the Tests have been changed (Please describe happened)

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have fully tested my code

# Test Coverage:

- Overall coverage: 93.56%
- Model coverage: 92.24%